### PR TITLE
fix: fixes global dot-env paths, failing with absolute path errors

### DIFF
--- a/examples/Runfile.yml
+++ b/examples/Runfile.yml
@@ -11,6 +11,9 @@ includes:
 env:
   global_k1: "v1"
 
+dotenv:
+  - ../.secrets/env
+
 tasks:
   cook:
     env:
@@ -25,16 +28,16 @@ tasks:
           # value: "this is default value"
           # sh: echo this should be the default value
           gotmpl: len "asdfadf"
-    dotenv:
-      - ../.secrets/env
+    # dotenv:
+    #   - ../.secrets/env
     cmd: 
       # - sleep 5
       # - echo "hi hello"
       # - echo "value of k1 is '$k1'"
       # - echo "value of k2 is '$k2'"
       # - echo "value of k3 is '$k3'"
-      # - echo "value of key_id (from .dotenv) is '$key_id', ${#key_id}"
       - echo "hello from cook"
+      - echo "value of key_id (from .dotenv) is '$key_id', ${#key_id}"
       - echo "k4 is $k4"
       - echo "k5 is $k5"
 

--- a/pkg/runfile/task-parser.go
+++ b/pkg/runfile/task-parser.go
@@ -37,7 +37,11 @@ func ParseTask(ctx Context, rf *Runfile, task Task) (*ParsedTask, *Error) {
 	}
 
 	if rf.DotEnv != nil {
-		m, err := parseDotEnvFiles(rf.DotEnv...)
+		dotEnvPaths, err := resolveDotEnvFiles(filepath.Dir(rf.attrs.RunfilePath), rf.DotEnv...)
+		if err != nil {
+			return nil, err
+		}
+		m, err := parseDotEnvFiles(dotEnvPaths...)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes #19

## Summary by Sourcery

Bug Fixes:
- Fix global dotenv paths to resolve absolute path errors by adjusting the path resolution logic.