### PR TITLE
feat: interactive commands support

### DIFF
--- a/examples/run1/Runfile
+++ b/examples/run1/Runfile
@@ -4,3 +4,8 @@ tasks:
   echo:
     cmd:
       - echo "hello from run1"
+
+  node:shell:
+    interactive: true
+    cmd:
+      - node

--- a/pkg/runfile/task-parser.go
+++ b/pkg/runfile/task-parser.go
@@ -13,10 +13,11 @@ import (
 )
 
 type ParsedTask struct {
-	Shell      []string          `json:"shell"`
-	WorkingDir string            `json:"workingDir"`
-	Env        map[string]string `json:"environ"`
-	Commands   []CommandJson     `json:"commands"`
+	Shell       []string          `json:"shell"`
+	WorkingDir  string            `json:"workingDir"`
+	Env         map[string]string `json:"environ"`
+	Interactive bool              `json:"interactive,omitempty"`
+	Commands    []CommandJson     `json:"commands"`
 }
 
 func ParseTask(ctx Context, rf *Runfile, task Task) (*ParsedTask, *Error) {
@@ -136,10 +137,11 @@ func ParseTask(ctx Context, rf *Runfile, task Task) (*ParsedTask, *Error) {
 	}
 
 	return &ParsedTask{
-		Shell:      task.Shell,
-		WorkingDir: *task.Dir,
-		Env:        fn.MapMerge(globalEnv, taskDotenvVars, taskEnvVars),
-		Commands:   commands,
+		Shell:       task.Shell,
+		WorkingDir:  *task.Dir,
+		Interactive: task.Interactive,
+		Env:         fn.MapMerge(globalEnv, taskDotenvVars, taskEnvVars),
+		Commands:    commands,
 	}, nil
 }
 

--- a/pkg/runfile/task-parser_test.go
+++ b/pkg/runfile/task-parser_test.go
@@ -29,6 +29,11 @@ func TestParseTask(t *testing.T) {
 			return false
 		}
 
+		if got.Interactive != want.Interactive {
+			t.Logf("interactive not equal")
+			return false
+		}
+
 		if len(got.Env) != len(want.Env) {
 			t.Logf("environments not equal")
 			return false
@@ -628,6 +633,44 @@ echo "hi"
 				taskName: "test",
 			},
 			wantErr: true,
+		},
+
+		{
+			name: "[task] interactive task",
+			args: args{
+				ctx: nil,
+				rf: &Runfile{
+					Tasks: map[string]Task{
+						"test": {
+							ignoreSystemEnv: true,
+							Interactive:     true,
+							Commands: []any{
+								"echo i will call hello, now",
+								map[string]any{
+									"run": "hello",
+								},
+							},
+						},
+						"hello": {
+							ignoreSystemEnv: true,
+							Commands: []any{
+								"echo hello everyone",
+							},
+						},
+					},
+				},
+				taskName: "test",
+			},
+			want: &ParsedTask{
+				Shell:       []string{"sh", "-c"},
+				WorkingDir:  fn.Must(os.Getwd()),
+				Interactive: true,
+				Commands: []CommandJson{
+					{Command: "echo i will call hello, now"},
+					{Run: "hello"},
+				},
+			},
+			wantErr: false,
 		},
 	}
 

--- a/pkg/runfile/task.go
+++ b/pkg/runfile/task.go
@@ -41,6 +41,8 @@ type Task struct {
 
 	Requires []*Requires `json:"requires,omitempty"`
 
+	Interactive bool `json:"interactive,omitempty"`
+
 	// List of commands to be executed in given shell (default: sh)
 	// can take multiple forms
 	//   - simple string


### PR DESCRIPTION
fixes issue with dumping stdout and stderr of commands, there was a bug in current implementation, as goroutines for reading and dumping stdout ere not going through a waitgroup, which caused them to abruptly exit, without logging the remaining stuffs

Resolves #21 

![image](https://github.com/user-attachments/assets/2e134704-cba5-4c61-aa11-35324ba21619)

## Summary by Sourcery

Introduce support for interactive commands by adding an 'interactive' flag to task configurations. Fix a bug related to premature goroutine exits when handling stdout and stderr. Enhance logging by adding task-specific prefixes and improve handling of line breaks. Add tests to validate the new interactive task functionality.

New Features:
- Add support for interactive commands by introducing an 'interactive' flag in the task configuration.

Bug Fixes:
- Fix issue with goroutines for reading and dumping stdout and stderr not using a waitgroup, which caused premature exits without logging remaining output.

Enhancements:
- Improve logging of stdout and stderr by adding task-specific prefixes and handling line breaks more effectively.

Tests:
- Add test cases to verify the functionality of interactive tasks, ensuring that tasks with the 'interactive' flag behave as expected.