### PR TITLE
refactor: adds a left rail for the command preview in runfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,37 +40,47 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: nxtcoder17/nixy@feat/github-action
+
       - uses: nxtcoder17/actions/setup-cache-go@v1
         with:
           cache_key: "run"
           working_directory: .
 
-      - uses: nxtcoder17/actions/setup-nix-cachix@v1
-        with:
-          flake_lock: "./flake.lock"
-          nix_develop_arguments: ".#default"
-          cachix_cache_name: ${{ secrets.CACHIX_CACHE_NAME }}
-          cachix_auth_token:  ${{ secrets.CACHIX_AUTH_TOKEN }}
+      # - uses: nxtcoder17/actions/setup-nix-cachix@v1
+      #   with:
+      #     flake_lock: "./flake.lock"
+      #     nix_develop_arguments: ".#default"
+      #     cachix_cache_name: ${{ secrets.CACHIX_CACHE_NAME }}
+      #     cachix_auth_token:  ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - uses: nxtcoder17/actions/metadata@main
         id: meta
+
+      # - name: Build Binary
+      #   shell: bash
+      #   env:
+      #     VERSION: ${{steps.meta.outputs.version}}
+      #   run: |+
+      #     nixy build runfile
 
       - name: Build Binary
         shell: bash
         env:
           CGO_ENABLED: 0
+          VERSION: "${{ steps.meta.outputs.version }}.${{ steps.meta.outputs.commit_slug }}"
         run: |+
           arch_list=("amd64" "arm64")
           os_list=("linux" "darwin")
 
+
           for os in "${os_list[@]}"; do
             for arch in "${arch_list[@]}"; do
-              echo "🚧 building binary for os=$os arch=$arch"
-              export GOARCH=$arch
               export GOOS=$os
+              export GOARCH=$arch
 
-              binary=bin/run-$GOOS-$GOARCH
-              time go build -o $binary -ldflags="-s -w -X main.Version=${{ steps.meta.outputs.version }}-${{steps.meta.outputs.short_sha}}" -tags urfave_cli_no_docs ./cmd/run
+              echo "🚧 building binary for os=$GOOS arch=$GOARCH"
+              go build -o bin/run-${GOOS}-${GOARCH} -ldflags="-s -w -X main.Version=$VERSION" -tags urfave_cli_no_docs ./cmd/run
             done
           done
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 Taskfile.yml
 go.work*
 tags
+.nixy

--- a/Runfile.yml
+++ b/Runfile.yml
@@ -2,18 +2,27 @@ tasks:
   build:
     env:
       CGO_ENABLED: 0
+      GOOS:
+        sh: go env GOOS
+      GOARCH:
+        sh: go env GOARCH
+      version:
+        required: true
     cmd: 
       - |+
         echo "building ..."
-        go build -o bin/run -ldflags="-s -w" -tags urfave_cli_no_docs ./cmd/run
+        go build -o bin/run-${GOOS}-${GOARCH} -ldflags="-s -w -X main.Version=$VERSION" -tags urfave_cli_no_docs ./cmd/run
         echo "DONE"
 
   build:dev:
+    watch:
+      enabled: true
+      dirs:
+        - .
     cmd: 
-      - |+
-        echo "building ..."
-        go build -o bin/run-nightly -ldflags="-s -w" -tags urfave_cli_no_docs ./cmd/run
-        echo "DONE"
+      - run: build
+        env:
+          version: "nightly"
 
   example:
     dir: ./examples

--- a/nixy.yml
+++ b/nixy.yml
@@ -6,7 +6,22 @@ packages:
   - pre-commit
   - gotestfmt
 
+builds:
+  runfile:
+    command: |+
+      echo "VERSION: $VERSION"
 
-onShellEnter: |+
-  export PATH="/workspace/bin:$PATH"
-  source $HOME/.profile
+      run build GOOS=linux GOARCH=amd64 version=$VERSION
+      run build GOOS=linux GOARCH=arm64 version=$VERSION
+      run build GOOS=darwin GOARCH=amd64 version=$VERSION
+      run build GOOS=darwin GOARCH=arm64 version=$VERSION
+
+    paths:
+      - ./bin/run-linux-amd64
+      - ./bin/run-linux-arm64
+      - ./bin/run-darwin-amd64
+      - ./bin/run-darwin-arm64
+
+# onShellEnter: |+
+#   export PATH="/workspace/bin:$PATH"
+#   # source $HOME/.profile

--- a/pkg/runfile/resolver/task.go
+++ b/pkg/runfile/resolver/task.go
@@ -291,18 +291,19 @@ func printCommand(w *writer.LogWriter, prefix, lang, cmd string) {
 
 	// w.Mu.Lock()
 	// defer w.Mu.Unlock()
-	fmt.Fprintf(w, "\r\033[K%s\n", padString(hlCode.String(), prefix))
+	fmt.Fprintf(w, "\r\033[K%s\n", formatCommandPreview(hlCode.String(), prefix))
 }
 
-func padString(str string, withPrefix string) string {
+func formatCommandPreview(str string, withPrefix string) string {
 	sp := strings.Split(str, "\n")
 	indent := strings.Repeat(" ", prefixDisplayWidth(withPrefix))
+	rail := lipgloss.NewStyle().Foreground(lipgloss.Color("2")).Faint(true).Render("│")
 	for i := range sp {
 		if i == 0 {
-			sp[i] = fmt.Sprintf("%s %s", writer.GetStyledPrefix(withPrefix), sp[i])
+			sp[i] = fmt.Sprintf("%s %s %s", writer.GetStyledPrefix(withPrefix), rail, sp[i])
 			continue
 		}
-		sp[i] = indent + sp[i]
+		sp[i] = indent + rail + " " + sp[i]
 	}
 
 	return strings.Join(sp, "\n")


### PR DESCRIPTION
## Summary by Sourcery

Update build and release workflows to use Nix-based builds and versioned multi-arch binaries, and add a left-rail visual treatment to command previews in the runfile UI.

Enhancements:
- Update Runfile tasks to produce versioned, architecture-specific binaries, add a dev build task with file watching, and refine command preview formatting with a styled left rail in the UI.

Build:
- Adjust GitHub release workflow to integrate the nixy action and build versioned multi-arch Go binaries without the previous Cachix setup.

Chores:
- Introduce nixy build configuration for runfile with defined build outputs and comment out shell initialization hooks.